### PR TITLE
Fix sample code formatting in README.md

### DIFF
--- a/labs/toolchain/README.md
+++ b/labs/toolchain/README.md
@@ -84,7 +84,7 @@ to can compile `Hello, world!` program for RISC-V you need:
 
 1. Dump program sample
 
-        echo "#include <stdio.h>\nint main() { printf("Hello, RISC-V!"); }" > hello.c
+        echo -e '#include <stdio.h> \n\nint main() { \n\tprintf("Hello, RISC-V!\\n"); \n}' > hello.c
 
 1. Compile
 


### PR DESCRIPTION
Updated the sample code to use echo -e for proper formatting.

There is an error in the original version:
```
> echo "#include <stdio.h>\nint main() { printf("Hello, RISC-V!"); }" > hello.c
bash: !": event not found
```